### PR TITLE
Lock YUI dependency to version 3.6.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
         "nopt": "*",
         "colors":"*",
         "express":"*",
-        "yui": "*",
+        "yui": "3.6.x",
         "JSV": "*",
         "log4js": "*",
         "clone": "*",


### PR DESCRIPTION
Arrow does not seem to work with YUI 3.5 ("YUITest is not defined" in yuitest-runner.js) so it should be locked down to the 3.6 versions.
