### PR TITLE
Using --browser setting will no longer automatically use selenium driver

### DIFF
--- a/lib/session/testsession.js
+++ b/lib/session/testsession.js
@@ -29,7 +29,7 @@ TestSession.prototype.setup = function (callback) {
     var DriverClass = null;
 
     if (!this.driverName) {
-        if (this.controller || this.testParams.page || this.args.browser || this.sessionId) {
+        if (this.controller || this.testParams.page || this.sessionId) {
             this.driverName = "selenium";
         } else {
             this.driverName = "nodejs";


### PR DESCRIPTION
This is important so that you can run descriptors that contain both selenium and nodejs tests. Without this change you are restricted to firefox browsers for mixed driver runs. I think this may be the cause for the race conditions I was seeing when running Mojito's tests (reported internally).
