### PR TITLE
Allow specifying controller with absolute path

### DIFF
--- a/lib/interface/arrow.js
+++ b/lib/interface/arrow.js
@@ -7,6 +7,7 @@
 */
 
 var log4js = require("log4js");
+var path = require("path");
 
 function Arrow(config, args) {
     this.logger = log4js.getLogger("Arrow");
@@ -39,7 +40,7 @@ Arrow.prototype.runController = function (controllerName, testConfig, testParams
 
     if (controllerName) {
         if (controllerName.indexOf(".js") !== -1) {
-            controllerName = process.cwd() + "/" + controllerName;
+            controllerName = path.resolve(process.cwd(), controllerName);
         } else {
             controllerName = this.config["arrowModuleRoot"] + "lib/controller/" + controllerName;
         }

--- a/tests/unit/lib/interface/arrow-tests.js
+++ b/tests/unit/lib/interface/arrow-tests.js
@@ -12,6 +12,7 @@ YUI.add('arrow-tests', function (Y, NAME) {
         Arrow = require(arrowRoot + '/lib/interface/arrow'),
         StubDriver = require(arrowRoot + '/tests/unit/stub/driver.js');
         controllerName = 'tests/unit/stub/controller.js';
+        controllerNameAbsolute = path.join(arrowRoot, controllerName);
         suite = new Y.Test.Suite(NAME),
         A = Y.Assert;
    
@@ -31,6 +32,15 @@ YUI.add('arrow-tests', function (Y, NAME) {
 
             arrow = new Arrow();
             arrow.runController(controllerName, {}, {param: "value"}, driver, function (errMsg, data, controller) {
+                executed = true;
+                A.isTrue(!errMsg, 'Should have successfully executed controller');
+                A.areEqual(controller.testParams.param, "value", "Controller should get the parameter");
+            });
+
+            A.isTrue(executed, 'Should have executed controller');
+            
+            executed = false;
+            arrow.runController(controllerNameAbsolute, {}, {param: "value"}, driver, function (errMsg, data, controller) {
                 executed = true;
                 A.isTrue(!errMsg, 'Should have successfully executed controller');
                 A.areEqual(controller.testParams.param, "value", "Controller should get the parameter");


### PR DESCRIPTION
The current code only allow relative controller path but in some cases we want to have a centralized location where test codes can share controllers locally. Arrow should support setting controller from absolute path. The path resolution is done by path.resolve: http://nodejs.org/api/path.html#path_path_resolve_from_to
