### PR TITLE
Fixed undefined error with descriptor fail count

### DIFF
--- a/lib/util/arrowrecursive.js
+++ b/lib/util/arrowrecursive.js
@@ -180,7 +180,7 @@ ArrowRecursive.prototype.showRecursiveReport = function (currentCount) {
         console.log("********************************************".bold.magenta);
         for (k in arrFailedDescriptors) {
             console.log("Failed Descriptor Path : ".grey +  k.toString().replace("report.json", this.descriptorName).red);
-            console.log("Total Number of Failed Tests : ".grey +  arrFailedDescriptors[k].red);
+            console.log("Total Number of Failed Tests : ".grey +  arrFailedDescriptors[k].toString().red);
             console.log("--------------------------------------------".bold.magenta);
         }
     }


### PR DESCRIPTION
The code was attempting to use the `red` property which is valid on Strings, but not on Numbers. This is fixed by converting the Number to a String.
