### PR TITLE
Add in-page functionality to locator controller's "click" feature

### DIFF
--- a/lib/controller/locator.js
+++ b/lib/controller/locator.js
@@ -64,7 +64,7 @@ LocatorController.prototype.execute = function (callback) {
      */
     stay = params["stay"];
     if (!stay) {
-        stay = true;
+        stay = false;
     }
     
     function done() {


### PR DESCRIPTION
Do not always expect a new page to load.  In the case of in-page interactions.  Like clicking to open a menu, currently locator controller hangs.
