### PR TITLE
Add debug message when loading descriptor file

### DIFF
--- a/lib/util/dataprovider.js
+++ b/lib/util/dataprovider.js
@@ -33,6 +33,7 @@ DataProvider.prototype.getTestData = function () {
         descriptorSchema,
         report;
 
+    this.logger.debug('Loading descriptor file: ' + this.testDataPath);
     descriptorJson = JSON.parse(fs.readFileSync(this.testDataPath, "utf-8"));
     baseUrl = this.config["baseUrl"];
     // inject baseUrl into the settings


### PR DESCRIPTION
Add debug message when loading descriptor file, to help diagnose syntax errors.
