### PR TITLE
Hotfix: Remove "arguments" for "use strict"

### DIFF
--- a/lib/client/yuitest-yuiloadercheck.js
+++ b/lib/client/yuitest-yuiloadercheck.js
@@ -3,7 +3,7 @@
 function checkURL(url, cb) {
     'use strict';
     YUI().use("io-xdr", function (Y) {
-        function onComplete(transactionid, response, arguments) {
+        function onComplete(transactionid, response, args) {
             // NOTE: In an XDR transaction, only the responseText or the responseXML property is defined.
 //            if(console)console.log(" Arrow server responese: "+response.responseText+" and status code: "+response.status);
             if (response.status === "200" || response.responseText === "yuiLoaderOK") {

--- a/tests/functional/arrow_commands.sh
+++ b/tests/functional/arrow_commands.sh
@@ -219,7 +219,7 @@ if [ $? != 0 ]; then
 } fi
 
 echo "TEST24: "
-CMD=`$ARROWCI ./data/arrow_test/sharelib-test-func-no-commonlib.json --browser=$BROWSERNAME --shareLibPath=./data/arrow_test/martini_lib/ --seleniumHost=$HUBHOST --capabilities=./cap.json | grep "LOG" >./data/actual_op/test24.txt`
+CMD=`$ARROWCI ./data/arrow_test/sharelib-test-func-no-commonlib.json --browser=$BROWSERNAME --shareLibPath=./data/arrow_test/martini_lib/ --seleniumHost=$HUBHOST --capabilities=./cap.json | tail -2 | head -1 >./data/actual_op/test24.txt`
 if [ $? != 0 ]; then
 {
     echo "ERROR!"
@@ -228,7 +228,7 @@ if [ $? != 0 ]; then
 } fi
 
 echo "TEST25: "
-CMD=`$ARROWCI ./data/arrow_test/sharelib-external-controller-test.json --browser=$BROWSERNAME --shareLibPath=./data/arrow_test/martini_lib/ --seleniumHost=$HUBHOST --capabilities=./cap.json | grep "LOG" >./data/actual_op/test25.txt`
+CMD=`$ARROWCI ./data/arrow_test/sharelib-external-controller-test.json --browser=$BROWSERNAME --shareLibPath=./data/arrow_test/martini_lib/ --seleniumHost=$HUBHOST --capabilities=./cap.json | tail -2 | head -1 >./data/actual_op/test25.txt`
 if [ $? != 0 ]; then
 {
     echo "ERROR!"

--- a/tests/functional/data/expected_op/expected_test24.txt
+++ b/tests/functional/data/expected_op/expected_test24.txt
@@ -1,2 +1,1 @@
-[LOG] TestRunner: test tab structure: passed.
-[LOG] TestRunner: test tab selection: passed.
+2 Passed, 0 Failed , 0 skipped


### PR DESCRIPTION
Seems that in the case of "use strict", the code with "arguments" is sensitive and cannot be ran on browser. This PR is the hotfix for this.
