### PR TITLE
Resolved path issue with proxy.log in proxymanager

### DIFF
--- a/lib/proxy/proxymanager.js
+++ b/lib/proxy/proxymanager.js
@@ -168,7 +168,7 @@ ProxyManager.prototype.writeLog = function (logLine) {
         data = decoder.write(logLine + "\n"),
         fd;
 
-    fd = fs.openSync(path.join(process.cwd(), this.fileName), 'a');
+    fd = fs.openSync(this.fileName, 'a');
     fs.writeSync(fd, data);
     fs.closeSync(fd);
 


### PR DESCRIPTION
Global.workingdirectory path was appended twice resulting in wrong path for proxy.log file.Fixed that issue
