### PR TITLE
global.reportFolder init

### DIFF
--- a/lib/util/arrowsetup.js
+++ b/lib/util/arrowsetup.js
@@ -45,7 +45,7 @@ ArrowSetup.prototype.errorCheck = function () {
 ArrowSetup.prototype.setupReportDir = function () {
 
     // To generate the reports, if either report is true or reportFolder is passed
-    global.reportFolder = "";
+    global.reportFolder = ""; 
     if (this.argv.reportFolder || true === this.argv.report) {
 
         var fileUtil = new FileUtil(),


### PR DESCRIPTION
global.reportFolder should be set a init value, otherwise if the condition not met,path resolve will throw error.
path.js:313
        throw new TypeError('Arguments to path.resolve must be strings');
              ^
TypeError: Arguments to path.resolve must be strings
    at Object.exports.resolve (path.js:313:15)
    at TestExecutor.deleteReport (/Users/jiliang/dev_env/git_source/arrow/lib/session/testexecutor.js:401:26)
    at iterate (/Users/jiliang/dev_env/git_source/arrow/node_modules/async/lib/async.js:123:13)
    at Object.async.eachSeries (/Users/jiliang/dev_env/git_source/arrow/node_modules/async/lib/async.js:145:9)
    at TestExecutor.cleanupReports (/Users/jiliang/dev_env/git_source/arrow/lib/session/testexecutor.js:423:15)
    at /Users/jiliang/dev_env/git_source/arrow/lib/session/testexecutor.js:383:22
    at TestExecutor.getTests (/Users/jiliang/dev_env/git_source/arrow/lib/session/testexecutor.js:298:5)
    at TestExecutor.startTest (/Users/jiliang/dev_env/git_source/arrow/lib/session/testexecutor.js:378:18)
    at TestExecutor.executeTests (/Users/jiliang/dev_env/git_source/arrow/lib/session/testexecutor.js:454:22)
    at SessionFactory.runAllTestSessions (/Users/jiliang/dev_env/git_source/arrow/lib/session/sessionfactory.js:112:18)
