### PR TITLE
Detect if command line argument is null value

### DIFF
--- a/config/error-messages.js
+++ b/config/error-messages.js
@@ -52,7 +52,7 @@ var pathNotFound = "Path is not defined", empty = "", error = {
 	},
 	1006 : {
 		name : 'ENULLARG',
-		text : 'Argument "{0}" is "null".'
+		text : 'Argument "{0}" is "{1}".'
 	}
 };
 

--- a/lib/util/arrowsetup.js
+++ b/lib/util/arrowsetup.js
@@ -192,23 +192,29 @@ ArrowSetup.prototype.errorCheck = function (cb) {
                 environment();
             }
         },
-        nullArgument = function() {
-            var argv = self.argv, i, arg, isNull = false, proc = self.mock || process;
+        invalidArgument = function() {
+            var argv = self.argv, i, arg, isNotValid = false, proc = self.mock || process;
             for (i in argv) {
                 arg = argv[i];
                 if (arg === null || arg === "null") {
-                    em.errorLog(1006, i);
-                    isNull = true;
+                    em.errorLog(1006, i, "null");
+                    isNotValid = true;
+                } else if (arg === '') {
+                    em.errorLog(1006, i, "empty string");
+                    isNotValid = true;
+                } else if (arg === undefined) {
+                    em.errorLog(1006, i, "undefined");
+                    isNotValid = true;
                 }
             }
-            if (isNull) {
+            if (isNotValid) {
                 proc.exit(1);
             }
             dimensions();
         };
 
     em.logger = self.mock || em.logger;
-    nullArgument();
+    invalidArgument();
     self.logger.trace('errorCheck ends..' + cb);
     if (cb) {
         cb();

--- a/tests/unit/lib/util/errormanager-tests.js
+++ b/tests/unit/lib/util/errormanager-tests.js
@@ -362,15 +362,16 @@ YUI.add('errormanager-tests', function(Y) {
     }));
 
     suite.add(new Y.Test.Case({
-        "ArrowSetup errorCheck should exit if multiple arguments have string value as 'null'": function(){
+        "ArrowSetup errorCheck should exit if multiple arguments have string value as 'null' or 'empty' or 'undefined'": function(){
             var ArrowSetup = require(arrowRoot+'/lib/util/arrowsetup.js'), arrow=undefined, exit="";
 
             mocks.invokeCount = 0;
             mocks.message = undefined;
             dimensions = JSON.parse(JSON.stringify(origDim));
             args = JSON.parse(JSON.stringify(origArgv));
-            args.dimensions = "null";
+            args.dimensions = '';
             args.seleniumHost = "null";
+            args.browser = undefined;
             msg[1006].name = "ENULLARGTEST";
             try {
                 arrow = new ArrowSetup({},args);
@@ -381,8 +382,10 @@ YUI.add('errormanager-tests', function(Y) {
             } finally {
                 Y.Assert.areSame("exit code is 1", exit, "should exit with exit code.");
                 Y.Assert.areSame(
-                    '1006 (ENULLARGTEST) Argument "dimensions" is "null".'+
-                    '1006 (ENULLARGTEST) Argument "seleniumHost" is "null".',
+                    '1006 (ENULLARGTEST) Argument "dimensions" is "empty string".'+
+                    '1006 (ENULLARGTEST) Argument "seleniumHost" is "null".'+
+                    '1006 (ENULLARGTEST) Argument "browser" is "undefined".',
+                    mocks.message[mocks.message.length-3]+
                     mocks.message[mocks.message.length-2]+
                     mocks.message[mocks.message.length-1]
                 );                


### PR DESCRIPTION
If any of the command line argument is null value or string "null",
Error manager will report errors and stop Arrow execution with exit
code 1.
