### PR TITLE
exempt capabilities from error 1006

### DIFF
--- a/lib/util/arrowsetup.js
+++ b/lib/util/arrowsetup.js
@@ -196,7 +196,9 @@ ArrowSetup.prototype.errorCheck = function (cb) {
             var argv = self.argv, arg, value, isNotValid = false, proc = self.mock || process,
                 exempt = {"capabilities":true};
             if (self.config.error1006) {
-                exempt = self.config.error1006.exempt || exempt;
+                for (arg in self.config.error1006.exempt) {
+                    exempt[arg] = self.config.error1006.exempt[arg];
+                }
             }
             for (arg in argv) {
                 if (exempt[arg]) {

--- a/tests/unit/lib/util/errormanager-tests.js
+++ b/tests/unit/lib/util/errormanager-tests.js
@@ -402,7 +402,7 @@ YUI.add('errormanager-tests', function(Y) {
             mocks.message = "mocks.message should not be modified in this test";
             dimensions = JSON.parse(JSON.stringify(origDim));
             args = JSON.parse(JSON.stringify(origArgv));
-            args.capabilities = '';
+            args.capabilities = ''; // by default, capabilities is exempted.
             msg[1006].name = "ENULLARGTEST";
             try {
                 arrow = new ArrowSetup({},args);
@@ -426,7 +426,7 @@ YUI.add('errormanager-tests', function(Y) {
             mocks.message = undefined;
             dimensions = JSON.parse(JSON.stringify(origDim));
             args = JSON.parse(JSON.stringify(origArgv));
-            args.capabilities = '';
+            args.dimensions = '';
             args.browser = undefined;
             msg[1006].name = "ENULLARGTEST";
             try {
@@ -438,10 +438,35 @@ YUI.add('errormanager-tests', function(Y) {
             } finally {
                 Y.Assert.areSame("exit code is 1", exit, "should exit with exit code.");
                 Y.Assert.areSame(
-                    '1006 (ENULLARGTEST) Argument "capabilities" is "empty string".',
+                    '1006 (ENULLARGTEST) Argument "dimensions" is "empty string".',
                     mocks.message[mocks.message.length-1]
                 );                
                 Y.Assert.areSame(1, mocks.invokeCount);                
+            }
+        }
+    }));
+
+    suite.add(new Y.Test.Case({
+        "ArrowSetup errorCheck should exempt arguments if config.error1006.exempt is specified but keep other existing exemption settings if it is not specified in config string": function(){
+            var ArrowSetup = require(arrowRoot+'/lib/util/arrowsetup.js'), arrow=undefined, exit="",
+                config = {"error1006":{"exempt":{"browser":true}}};
+
+            mocks.invokeCount = 0;
+            mocks.message = "mocks.message should not be modified in this test";
+            dimensions = JSON.parse(JSON.stringify(origDim));
+            args = JSON.parse(JSON.stringify(origArgv));
+            args.capabilities = ''; // by default, capabilities is exempted.
+            args.browser = undefined;
+            msg[1006].name = "ENULLARGTEST";
+            try {
+                arrow = new ArrowSetup(config,args);
+                arrow.mock = mocks;
+                arrow.errorCheck();
+            } catch (e) {
+                exit = e.message;
+            } finally {
+                Y.Assert.areSame("mocks.message should not be modified in this test", mocks.message);
+                Y.Assert.areSame(0, mocks.invokeCount);                
             }
         }
     }));


### PR DESCRIPTION
Added two unit tests.

ArrowSetup errorCheck should exempt capabilities from error 1006 if its
value is null or empty or undefined

ArrowSetup errorCheck should exempt arguments if
config.error1006.exempt is specified

For example, to exempt "browser" from error 1006 checking.
config.error1006 = {"exempt":{"browser":true}};
