### PR TITLE
Null argument

### DIFF
--- a/lib/util/arrowsetup.js
+++ b/lib/util/arrowsetup.js
@@ -193,17 +193,21 @@ ArrowSetup.prototype.errorCheck = function (cb) {
             }
         },
         invalidArgument = function() {
-            var argv = self.argv, i, arg, isNotValid = false, proc = self.mock || process;
-            for (i in argv) {
-                arg = argv[i];
-                if (arg === null || arg === "null") {
-                    em.errorLog(1006, i, "null");
+            var argv = self.argv, arg, value, isNotValid = false, proc = self.mock || process,
+                mandatory = { "seleniumHost" : true };
+            for (arg in argv) {
+                if (mandatory[arg] === undefined || !mandatory[arg]) {
+                    continue;
+                }
+                value = argv[arg];
+                if (value === null || value === "null") {
+                    em.errorLog(1006, arg, "null");
                     isNotValid = true;
-                } else if (arg === '') {
-                    em.errorLog(1006, i, "empty string");
+                } else if (value === '') {
+                    em.errorLog(1006, arg, "empty string");
                     isNotValid = true;
-                } else if (arg === undefined) {
-                    em.errorLog(1006, i, "undefined");
+                } else if (value === undefined) {
+                    em.errorLog(1006, arg, "undefined");
                     isNotValid = true;
                 }
             }

--- a/tests/unit/lib/util/errormanager-tests.js
+++ b/tests/unit/lib/util/errormanager-tests.js
@@ -335,14 +335,14 @@ YUI.add('errormanager-tests', function(Y) {
     }));
 
     suite.add(new Y.Test.Case({
-        "ArrowSetup errorCheck should exit if single argument has string value as 'null'": function(){
+        "ArrowSetup errorCheck should exit if single mandatory argument has string value as 'null'": function(){
             var ArrowSetup = require(arrowRoot+'/lib/util/arrowsetup.js'), arrow=undefined, exit="";
 
             mocks.invokeCount = 0;
             mocks.message = undefined;
             dimensions = JSON.parse(JSON.stringify(origDim));
             args = JSON.parse(JSON.stringify(origArgv));
-            args.dimensions = "null";
+            args.seleniumHost = "null"; // seleniumHost is mandatory.
             msg[1006].name = "ENULLARGTEST";
             try {
                 arrow = new ArrowSetup({},args);
@@ -353,7 +353,7 @@ YUI.add('errormanager-tests', function(Y) {
             } finally {
                 Y.Assert.areSame("exit code is 1", exit, "should exit with exit code.");
                 Y.Assert.areSame(
-                    '1006 (ENULLARGTEST) Argument "dimensions" is "null".',
+                    '1006 (ENULLARGTEST) Argument "seleniumHost" is "null".',
                     mocks.message[mocks.message.length-1]
                 );                
                 Y.Assert.areSame(1, mocks.invokeCount);                
@@ -362,7 +362,7 @@ YUI.add('errormanager-tests', function(Y) {
     }));
 
     suite.add(new Y.Test.Case({
-        "ArrowSetup errorCheck should exit if multiple arguments have string value as 'null' or 'empty' or 'undefined'": function(){
+        "ArrowSetup errorCheck should exit if mandatory arguments have string value as 'null' or 'empty' or 'undefined'": function(){
             var ArrowSetup = require(arrowRoot+'/lib/util/arrowsetup.js'), arrow=undefined, exit="";
 
             mocks.invokeCount = 0;
@@ -370,7 +370,7 @@ YUI.add('errormanager-tests', function(Y) {
             dimensions = JSON.parse(JSON.stringify(origDim));
             args = JSON.parse(JSON.stringify(origArgv));
             args.dimensions = '';
-            args.seleniumHost = "null";
+            args.seleniumHost = "null"; // only seleniumHost is mandatory.
             args.browser = undefined;
             msg[1006].name = "ENULLARGTEST";
             try {
@@ -382,11 +382,7 @@ YUI.add('errormanager-tests', function(Y) {
             } finally {
                 Y.Assert.areSame("exit code is 1", exit, "should exit with exit code.");
                 Y.Assert.areSame(
-                    '1006 (ENULLARGTEST) Argument "dimensions" is "empty string".'+
-                    '1006 (ENULLARGTEST) Argument "seleniumHost" is "null".'+
-                    '1006 (ENULLARGTEST) Argument "browser" is "undefined".',
-                    mocks.message[mocks.message.length-3]+
-                    mocks.message[mocks.message.length-2]+
+                    '1006 (ENULLARGTEST) Argument "seleniumHost" is "null".',
                     mocks.message[mocks.message.length-1]
                 );                
                 Y.Assert.areSame(1, mocks.invokeCount);                


### PR DESCRIPTION
Revert previous pull request and redo it.
Right now, only seleniumHost is mandatory if it is provided on command line.
For other arguments, if they are null argument, Arrow will either ignore it or get default value.
