### PR TITLE
Handle the Error 1004 Arrow is not defined

### DIFF
--- a/lib/driver/selenium.js
+++ b/lib/driver/selenium.js
@@ -108,7 +108,7 @@ SeleniumDriver.prototype.errorCheck = function (e, callback) {
             try {
                 self.webdriver.getCurrentUrl()
                     .then(matchError(handleIssueWithPageLoading))
-                    .then(matchError(handleUnknownError)) // keephandleUnknownError as last error handler
+                    .then(matchError(handleUnknownError)) // keep handleUnknownError as last error handler
                     // Something wrong in webdriver. Print the originial error message.
                     .then(null, function () {callback(errorMessage);});
             } catch (e) {
@@ -816,7 +816,7 @@ SeleniumDriver.prototype.executeTest = function (testConfig, testParams, callbac
             setTimeout(collectTestReport, self.attemptInterval);
         },
             function(err) {
-                self.testCallback(err);
+                self.errorCheck(err, self.testCallback);
             });
     }
 

--- a/lib/driver/selenium.js
+++ b/lib/driver/selenium.js
@@ -767,7 +767,8 @@ SeleniumDriver.prototype.executeTest = function (testConfig, testParams, callbac
         },
             function(e) {
                 self.logger.error('collectTestReport:webdriver.executeScript:' + e);
-                self.errorCallback(logger, 'Error while executing script : ' + e, callback);
+                //self.errorCallback(logger, 'Error while executing script : ' + e, callback);
+                self.errorCheck('Error while executing script : ' + e, self.testCallback);
             });
 
     }

--- a/lib/driver/selenium.js
+++ b/lib/driver/selenium.js
@@ -105,7 +105,16 @@ SeleniumDriver.prototype.errorCheck = function (e, callback) {
                 "Unable to send request: socket hang up)"))) {
             handleUnknownError();
         } else {
-            callback(errorMessage);
+            try {
+                self.webdriver.getCurrentUrl()
+                    .then(matchError(handleIssueWithPageLoading))
+                    .then(matchError(handleUnknownError)) // keephandleUnknownError as last error handler
+                    // Something wrong in webdriver. Print the originial error message.
+                    .then(null, function () {callback(errorMessage);});
+            } catch (e) {
+                // Something wrong in webdriver. Print the originial error message.
+                callback(errorMessage);
+            }
         }
     }
 };

--- a/tests/unit/lib/util/errormanager-tests.js
+++ b/tests/unit/lib/util/errormanager-tests.js
@@ -468,20 +468,19 @@ YUI.add('errormanager-tests', function(Y) {
             msg[1002].name = 'EREPORTEST';
             msg[1004].name = "EUNDEFTEST";
             try {
-                throw new Error("Issue with loading testing page");
+                throw new Error("ReferenceError: ARROW is not defined");
             } catch(e) {
                 callback = function (errMsg) {
                     started = true;
 
-                    Y.Assert.areSame('Error: Issue with loading testing page',errMsg);
-//                    Y.Assert.areSame(
-//                        '1004 (EUNDEFTEST) Issue with loading testing page about:blank\n' +
-//                            'Possible cause :\n' +
-//                            'The page got redirected before completing the test, this happens if your page has auto-redirects ' +
-//                            'or your tests perform some UI action resulting into page change event. Please use a custom controller for these kind of issues.\n' +
-//                            'If you are already using custom controller, please check that you are using waitForElement(s) to ensure page is ready for executing test.\n' +
-//                            'For Arrow Usage, please refer to https://github.com/yahoo/arrow/blob/master/docs/arrow_cookbook/README.rst',
-//                        errMsg);
+                    Y.Assert.areSame(
+                       '1004 (EUNDEFTEST) Issue with loading testing page about:blank\n' +
+                           'Possible cause :\n' +
+                           'The page got redirected before completing the test, this happens if your page has auto-redirects ' +
+                           'or your tests perform some UI action resulting into page change event. Please use a custom controller for these kind of issues.\n' +
+                           'If you are already using custom controller, please check that you are using waitForElement(s) to ensure page is ready for executing test.\n' +
+                           'For Arrow Usage, please refer to https://github.com/yahoo/arrow/blob/master/docs/arrow_cookbook/README.rst',
+                       errMsg);
                 };
                 started = false;
                 seleniumDriver.errorCheck(e, callback);


### PR DESCRIPTION
Add more error handling when webdriver itself got javascript exception.
Should print the original error message if any issues happened during webdriver.getCurrentUrl().

Do more Error Manager error checking in function, such as testing initialization and reporting.

For more details, please refer to the following webdriver exception.
While invoking getCurrentUrl(), the function will check if the webdriver session is not null.
Otherwise, webdriver will throw a regular javascript exception.

 at checkHasNotQuit
(/***\* hudson job test job ****/func-test/node_modules/yahoo-arrow/ext-lib/webdriver/lib/webdriver/webdriver.js:283:13)

  function checkHasNotQuit() {
    if (!self.session_) {
      throw new Error('This driver instance does not have a valid session ID ' +
                      '(did you call WebDriver.quit()?) and may no longer be ' +
                      'used.');
    }
  }
