### PR TITLE
Support https port 443

### DIFF
--- a/lib/controller/webservice-controller.js
+++ b/lib/controller/webservice-controller.js
@@ -58,6 +58,9 @@ WebServiceController.prototype.execute = function(callback) {
     var http_protocol;
     if (parts.protocol.indexOf("https") > -1) {
         http_protocol = https;
+        if (http_opts.port === '80') {
+            http_opts.port = '443';
+        }
     } else {
         http_protocol = http;
     }


### PR DESCRIPTION
To workaround a SSL bug in https module for node 0.8.4-0.8.22 as
mentioned at https://github.com/joyent/node/issues/4771
