### PR TITLE
setting strict ssl to false to allow compatibilty for node 0.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,5 @@ node_js:
   - 0.6
   - 0.8
   - 0.10.1
+before_install:
+  - npm conf set strict-ssl false


### PR DESCRIPTION
The builds for node 0.6 failed as a result of the SSL CERT issues discussed here: https://github.com/isaacs/npm/issues/4379

Though this is not the most ideal thing to do, for supporting 0.6 this might have to be done atm. Some more discussion about it can be read at https://github.com/isaacs/npm-www/issues/185
