### PR TITLE
Adding badge to watch nodejs dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,8 @@ arrow --controller=custom-controller.js --driver=selenium
 
 ##Arrow Dependencies
 
+[![Dependency Status](https://david-dm.org/yahoo/arrow.png)](https://david-dm.org/yahoo/arrow)
+
 NPM Dependencies
 * **glob** https://github.com/isaacs/node-glob
 * **nopt** https://github.com/isaacs/nopt


### PR DESCRIPTION
https://david-dm.org/yahoo/arrow will help keep track of stable/ out of
date or pinned dependencies. Provides an easy visual representation of
dependency status.
