### PR TITLE
Whitelist a few inline styles - exclude more empty elements

### DIFF
--- a/lib/common/tests/markup-test.js
+++ b/lib/common/tests/markup-test.js
@@ -115,22 +115,13 @@ YUI.add("markup-common-tests", function (Y) {
                 error.push({level: 'warn', text: 'Legacy style attribute found on table.'});
             }
 
-            if(Y.one('*[width]')  ||
-               Y.one('*[height]') ||
+            if(Y.one('*:not(img):not(iframe)[width]')  ||
+               Y.one('*:not(img):not(iframe)[height]') ||
                Y.one('*[border]')) {
                 error.push({level: 'warn', text: 'Legacy style attribute found on element.'});
             }
 
-            if(Y.one('div:empty')  ||
-               Y.one('span:empty') ||
-               Y.one('p:empty')    ||
-               Y.one('ul:empty')   ||
-               Y.one('ol:empty')   ||
-               Y.one('dl:empty')   ||
-               Y.one('li:empty')   ||
-               Y.one('dt:empty')   ||
-               Y.one('dd:empty')   ||
-               Y.one('a:empty')) {
+            if(Y.one('*:not(area):not(base):not(br):not(col):not(embed):not(hr):not(iframe):not(img):not(input):empty')) {
                 error.push({level: 'warn', text: 'Empty element - is it necessary?'});
             }
 


### PR DESCRIPTION
`<img>` tags should have height and width attributes.  Iframes too, I
guess.

Allow only void elements to be empty - highlight error to any other
empty element.
