### PR TITLE
Add docs, code coverage and tests to .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -5,3 +5,13 @@
 CVS/
 .DS_Store
 package.json.pl
+coverage
+tests
+docs
+demo
+results.xml
+lcov-report
+tmp
+.travis.yml
+ytestrunner.json
+lcov.info


### PR DESCRIPTION
@proverma Cleaning up the .npmignore for Arrow. The package that gets installed by users has a bunch of files that are test files/docs. Adding these to npmignore also brings down the size of the package by 4.6MB

```
coverage
demo
docs
index.js
lcov-report
lcov.info
nodejs
results.xml
tests
tmp
ytestrunner.json
```
