### PR TITLE
Reverting gitignore and npmignore 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,6 @@ lib/.DS_Store
 results.xml
 report.*
 coverage
-child_process_coverage
 npm-debug.log
 tmp/arrow_server.status
 tmp/*.js

--- a/.npmignore
+++ b/.npmignore
@@ -5,13 +5,3 @@
 CVS/
 .DS_Store
 package.json.pl
-coverage
-tests
-docs
-demo
-results.xml
-lcov-report
-tmp
-.travis.yml
-ytestrunner.json
-lcov.info


### PR DESCRIPTION
The pull request https://github.com/yahoo/arrow/pull/182 caused regression with arrow_server start up. Its no longer able to create tmp/arrow_server.status file. 
