### PR TITLE
Using cdnjs link for chai.js and protocol independent urls for mocha & expect

### DIFF
--- a/lib/engine/mocha/mocha-seed.js
+++ b/lib/engine/mocha/mocha-seed.js
@@ -71,12 +71,12 @@ mochaSeed.prototype.generateServerSideSeed = function (cb) {
 mochaSeed.prototype.generateClientSideSeed = function (cb) {
 
     var self = this,
-        MOCHA_LINK = "http://cdnjs.cloudflare.com/ajax/libs/mocha/1.13.0/mocha.js",
+        MOCHA_LINK = "//cdnjs.cloudflare.com/ajax/libs/mocha/1.13.0/mocha.js",
         DEFAULT_UI = "bdd",
-    // chai is default supported and we will use official url
+    // chai is default supported
         DEFAULT_ASSERTION = {
-            "chai": "http://chaijs.com/chai.js",
-            "expect": "http://cdnjs.cloudflare.com/ajax/libs/expect.js/0.2.0/expect.js"
+            "chai": "//cdnjs.cloudflare.com/ajax/libs/chai/1.9.0/chai.js",
+            "expect": "//cdnjs.cloudflare.com/ajax/libs/expect.js/0.2.0/expect.js"
         },
         mods;
 


### PR DESCRIPTION
Using cdnjs link for chai.js and protocol independent urls for mocha & expect
