### PR TITLE
Turn off socket connection limiting in http.request()

### DIFF
--- a/lib/proxy/proxymanager.js
+++ b/lib/proxy/proxymanager.js
@@ -262,6 +262,8 @@ ProxyManager.prototype.runRouterProxy = function (minPort, maxPort, host, callba
                         handle = options.headers['protocol'] === 'https:' ? 'https' : 'http';
                         f_http = require('./../../ext-lib/follow_redirect_http.js')[handle];
 
+                        options.agent = false;
+
                         proxy_request = f_http.request(options, function (proxy_response) {
 
                             // Record network traffic


### PR DESCRIPTION
fixes #194 
