### PR TITLE
exporting paths so that we can require('yahoo-arrow/index.js') 

### DIFF
--- a/index.js
+++ b/index.js
@@ -160,3 +160,7 @@ if (config.shareLibPath !== undefined) {
 } else {
     startArrow();
 }
+
+exports.path = function() {
+    return __dirname;
+};


### PR DESCRIPTION
This helps us locate the correct bin path for arrow especially when there are multiple versions of arrow installed
