### PR TITLE
Setting rejectUnauthorized to false for webservice controller

### DIFF
--- a/lib/controller/webservice-controller.js
+++ b/lib/controller/webservice-controller.js
@@ -51,7 +51,8 @@ WebServiceController.prototype.execute = function(callback) {
         method: self.testParams.method || 'GET',
         headers: { // seems that user-agent is MUST to query YQL
             'user-agent': "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_7_5) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.65 Safari/537.31"
-        } 
+        },
+        rejectUnauthorized: false
     }
 
     // http or https?


### PR DESCRIPTION
Nodejs 10 onwards, rejectUnauthorized is set to true by default. Setting it explicitly to false to avoid the error - UNABLE_TO_VERIFY_LEAF_SIGNATURE
