### PR TITLE
Fix for screenshots getting overwritten if there are multiple test failures in one descriptor

### DIFF
--- a/lib/session/testsession.js
+++ b/lib/session/testsession.js
@@ -269,7 +269,7 @@ TestSession.prototype.recordFailure = function (count, callback) {
         testName = "arrow-";
 
         if (self.args && self.args.testName) {
-            testName += "arrow-" + self.args.testName;
+            testName = "arrow-" + self.args.testName;
         } else {
             testName = "arrow";
         }


### PR DESCRIPTION
To fix the issue - #269
