### PR TITLE
Updating capabilities for iOS

### DIFF
--- a/lib/util/capabilitymanager.js
+++ b/lib/util/capabilitymanager.js
@@ -96,7 +96,7 @@ CapabilityManager.prototype.getCapabilities = function (args, config) {
 
     var self = this,
         caps = {
-            "platform": "ANY",
+//            "platform": "ANY",
             "javascriptEnabled": true,
             "seleniumProtocol": "WebDriver"
         };
@@ -159,8 +159,10 @@ CapabilityManager.prototype.setMobileCaps = function(caps) {
     //extra properties required for appium
     //ios case
     if (browserName === "iphone" || browserName === "ipad") {
-        caps.device = browserName;
-        caps.app = "safari";
+
+        caps.platformName = "iOS";
+        caps.deviceName = browserName;
+        caps.browserName = "Safari";
 
         // Remove version property if set to latest
         if (caps.version === "latest") {

--- a/tests/unit/lib/util/capabilitymanager-tests.js
+++ b/tests/unit/lib/util/capabilitymanager-tests.js
@@ -145,8 +145,10 @@ YUI.add('capabilitymanager-tests', function(Y) {
 
             caps = cm.setMobileCaps(caps);
 
-            Y.Assert.areEqual('iphone',caps.device,"Caps device should be iphone");
-            Y.Assert.areEqual('safari',caps.app,"Caps app should be safari");
+            Y.Assert.areEqual('iphone',caps.deviceName,"Caps deviceName should be iphone");
+            Y.Assert.areEqual('iOS',caps.platformName,"Caps platformName should be iOS");
+            Y.Assert.areEqual('Safari',caps.browserName,"Caps browserName should be Safari");
+
         }
     }));
 


### PR DESCRIPTION
Setting 
platformName to "iOS"
deviceName to "iphone/ipad" ( the browserName passed from command line ) 
browserName to "Safari"

to be compatible with Appium 1.2
