### PR TITLE
Adding support for specifying sauce tunnel

### DIFF
--- a/lib/util/capabilitymanager.js
+++ b/lib/util/capabilitymanager.js
@@ -265,6 +265,13 @@ CapabilityManager.prototype.setSauceCaps = function (caps, config) {
 		this.logger.debug('Setting capabilities for Saucelabs');
 		caps.username = config.sauceUsername || process.env.SAUCE_USERNAME;
 		caps.accessKey = config.sauceAccesskey || process.env.SAUCE_ACCESS_KEY;
+		caps['parent-tunnel'] = config.sauceTunnel || process.env.SAUCE_TUNNEL;
+		this.logger.debug("Sauce username :" + caps.username);
+		if (caps['parent-tunnel']) {
+			this.logger.debug("Sauce tunnel :" + caps['parent-tunnel']);
+		} else {
+			this.logger.debug("Not using Sauce tunnel");
+		}
 	}
 	return caps;
 };

--- a/tests/unit/lib/util/capabilitymanager-tests.js
+++ b/tests/unit/lib/util/capabilitymanager-tests.js
@@ -209,11 +209,13 @@ YUI.add('capabilitymanager-tests', function(Y) {
            config.isSauceLabs = true;
            config.sauceUsername = "sauceuser";
            config.sauceAccesskey = "saucekey";
+           config.sauceTunnel = "sauceTunnel";
 
            caps = cm.setSauceCaps(caps, config);
 
             Y.Assert.areEqual('sauceuser',caps.username, "Capabilities username doesnt match when passed from config");
             Y.Assert.areEqual('saucekey',caps.accessKey, "Capabilities accesskey doesnt match when passed from config");
+            Y.Assert.areEqual('sauceTunnel',caps['parent-tunnel'], "Capabilities parent-tunnel doesnt match when passed from config");
         }
     }));
 
@@ -228,6 +230,7 @@ YUI.add('capabilitymanager-tests', function(Y) {
 
             Y.Assert.isUndefined(caps.username, "Capabilities username should be undefined");
             Y.Assert.isUndefined(caps.accessKey, "Capabilities accesskey should be undefined");
+            Y.Assert.isUndefined(caps['parent-tunnel'], "Capabilities parent-tunnel should be undefined");
         }
     }));
 
@@ -241,11 +244,13 @@ YUI.add('capabilitymanager-tests', function(Y) {
            config.isSauceLabs = true;
            process.env.SAUCE_USERNAME = "sauceuser";
            process.env.SAUCE_ACCESS_KEY = "saucekey";
+           process.env.SAUCE_TUNNEL = "sauceTunnel";
 
            caps = cm.setSauceCaps(caps, config);
 
             Y.Assert.areEqual('sauceuser',caps.username, "Capabilities username doesnt match when passed from environment");
             Y.Assert.areEqual('saucekey',caps.accessKey, "Capabilities accesskey doesnt match when passed from environment");
+            Y.Assert.areEqual('sauceTunnel',caps['parent-tunnel'], "Capabilities accesskey doesnt match when passed from environment");
 
             delete process.env.SAUCE_USERNAME;
             delete process.env.SAUCE_ACCESS_KEY;


### PR DESCRIPTION
Adding support for specifying sauce tunnel

User can specify the tunnel identifier in config [ sauceTunnel='mytunnel'] or an environment variable - SAUCE_TUNNEL.